### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [Taskade MCP Server](https://github.com/taskade/mcp): Official Taskade MCP server for Cursor. Connect AI to Taskade workspaces for project management, notes, mind maps, AI agents, and workflow automation.  ![GitHub Repo stars](https://img.shields.io/github/stars/taskade/mcp)
 
 
 


### PR DESCRIPTION
[Taskade MCP Server](https://github.com/taskade/mcp) — Official open-source MCP server for Taskade. Connect Cursor to Taskade workspaces for project management, notes, mind maps, AI agents, and workflow automation.

GitHub: https://github.com/taskade/mcp
Website: https://taskade.com