### PR TITLE
Add Skills section with agentskill.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ A list of cursor topics.
 
 
 
+## Skills
+
+- [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
+
 ## Other
 
 - [Older versions Cursor](https://github.com/oslook/cursor-ai-downloads): Provide links to download older versions of Cursor. ![GitHub Repo stars](https://img.shields.io/github/stars/oslook/cursor-ai-downloads)


### PR DESCRIPTION
Adds a new Skills section featuring [agentskill.sh](https://agentskill.sh).

**What it is:**
- Directory of 44k+ skills for Cursor, Claude Code, Codex
- Two-layer security scanning across 12 threat categories
- One-command installation via `/learn` skill

[Browse skills](https://agentskill.sh) | [Security dashboard](https://agentskill.sh/security)