### PR TITLE
Add Mantra - AI coding session time-machine for Cursor users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A list of cursor topics.
 - [CursorLens](https://github.com/HamedMP/CursorLens): An open-source dashboard for Cursor.sh IDE. Log AI code generations, track usage, and control AI models (including local ones). Run locally or use upcoming hosted version. ![GitHub Repo stars](https://img.shields.io/github/stars/HamedMP/CursorLens)
 - [Chrome Debug Monitor](https://github.com/Maxteabag/cursor-chrome-composer): A powerful integration between Chrome's DevTools Protocol and Cursor Composer for real-time debugging and monitoring. ![GitHub Repo stars](https://img.shields.io/github/stars/Maxteabag/cursor-chrome-composer)
 - [cursor-tools](https://github.com/dougwithseismic/cursor-tools): A powerful desktop application for managing and enhancing your Cursor IDE notepads, built with Electron, React, and TypeScript. ![GitHub Repo stars](https://img.shields.io/github/stars/dougwithseismic/cursor-tools)
+- [Mantra](https://mantra.gonewx.com): Session time-machine for AI coding tools (Claude Code, Cursor, Windsurf). Save, restore, and time-travel through your Cursor sessions. Never lose your AI coding context again.
 
 ## Extensions
 


### PR DESCRIPTION
## What is Mantra?

**[Mantra](https://mantra.gonewx.com)** is an AI coding session time machine that lets you save, restore, and time-travel through your Cursor (and Claude Code, Gemini CLI, Codex (Windsurf: In Development)) sessions.

## Why add it?

This list focuses on tools and resources that enhance the Cursor experience. Mantra directly helps Cursor users by:
- Saving session state so you never lose AI context when switching projects
- Letting you restore previous sessions with one click
- Supporting Cursor natively alongside Claude Code, Gemini CLI, and Codex (Windsurf: In Development)
- Available for macOS, Windows & Linux

## Where I added it

Added under **Projects** section as it's a standalone tool for Cursor users (not an extension or plugin per se, but a companion desktop app).

```
- [Mantra](https://mantra.gonewx.com): Session time-machine for AI coding tools (Claude Code, Cursor, Gemini CLI, Codex (Windsurf: In Development)). Save, restore, and time-travel through your Cursor sessions. Never lose your AI coding context again.
```