### PR TITLE
Add onUI - UI Annotation MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [onUI](https://github.com/onllm-dev/onUI): Browser extension and MCP server for annotation-first UI pair programming with AI agents. ![GitHub Repo stars](https://img.shields.io/github/stars/onllm-dev/onUI)
 
 
 


### PR DESCRIPTION
## Summary

Add [onUI](https://github.com/onllm-dev/onUI) to the MCPs section.

onUI is a browser extension and MCP server that enables annotation-first UI pair programming with AI agents. It allows users to annotate web UI elements directly in the browser and share that context with AI coding agents through the Model Context Protocol.

**Cursor compatibility:** onUI works with Cursor via its MCP server integration, letting Cursor's AI agent see and understand UI annotations, screenshots, and page context for more accurate frontend development assistance.