### PR TITLE
Add TokRepo Search Skill to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A list of cursor topics.
 ## Skills
 
 - [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
+- [TokRepo Search Skill](https://github.com/henu-wang/tokrepo-search-skill): Cross-platform TokRepo skill for finding and installing AI assets including Cursor rules, MCP configs, prompts, and workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/henu-wang/tokrepo-search-skill)
 
 ## Other
 


### PR DESCRIPTION
Adds TokRepo Search Skill to the `Skills` section.

Why it fits:
- it is a GitHub-hosted cross-platform skill repo
- it helps Cursor users discover installable AI assets, including Cursor rules, MCP configs, prompts, and workflows
- it complements direct rule collections by acting as a searchable registry entry point
