### PR TITLE
Add code-tour to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A list of cursor topics.
 ## Skills
 
 - [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
+- [code-tour](https://github.com/vaddisrinivas/code-tour): AI-generated CodeTour walkthroughs for any codebase. Creates persona-targeted .tour files with step-by-step explanations linked to real files and line numbers. Works with VS Code CodeTour extension. ![GitHub Repo stars](https://img.shields.io/github/stars/vaddisrinivas/code-tour)
 
 ## Other
 


### PR DESCRIPTION
[code-tour](https://github.com/vaddisrinivas/code-tour) generates CodeTour-compatible `.tour` files for any codebase using AI. It creates persona-targeted, step-by-step walkthroughs linked to real files and line numbers, working with the VS Code CodeTour extension.

- **Install**: `npx skills add vaddisrinivas/code-tour`
- **License**: MIT
- Added under **Skills** section with star badge matching existing format