### PR TITLE
Add TopRank seo-analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A list of cursor topics.
 ## Skills
 
 - [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
+- [seo-analysis](https://github.com/nowork-studio/toprank/blob/main/seo/seo-analysis/SKILL.md): SEO audit skill for Cursor, Claude Code, and Codex with Search Console, PageSpeed, keyword research, metadata, and schema checks. ![GitHub Repo stars](https://img.shields.io/github/stars/nowork-studio/toprank)
 
 ## Other
 


### PR DESCRIPTION
Adds `seo-analysis` from `nowork-studio/toprank` to the `Skills` section.

`seo-analysis` is a directly usable skill file for Cursor, Claude Code, and Codex. It focuses on practical SEO audits with Google Search Console, PageSpeed Insights, keyword research, metadata checks, and schema validation.

## Credibility
`nowork-studio/toprank` currently has **124 GitHub stars** and is MIT licensed.

## Why it fits
This repo already curates Cursor-adjacent skills and resources. Linking the standalone `seo-analysis` `SKILL.md` gives Cursor users a concrete, installable workflow resource without forcing the broader Claude Code plugin surface into the list.

Source: https://github.com/nowork-studio/toprank
