### PR TITLE
Add Cursor MCP to the list of extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A list of cursor topics.
 - [specstory](https://github.com/specstoryai/getspecstory): SpecStory automatically saves every Cursor chat and composer session to your local project's .specstory directory. ![GitHub Repo stars](https://img.shields.io/github/stars/specstoryai/getspecstory)
 - [Cursor Stats](https://github.com/Dwtexe/cursor-stats): A Cursor extension that displays your Cursor Subscription usage statistics in the status bar. ![GitHub Repo stars](https://img.shields.io/github/stars/Dwtexe/cursor-stats)
 - [stagewise](https://github.com/stagewise-io/stagewise): stagewise is a browser toolbar that connects your frontend UI to your code ai agents in your code editor. ![GitHub Repo stars](https://img.shields.io/github/stars/stagewise-io/stagewise)
+- [Cursor MCP](https://github.com/2029193370/cursor-mcp): Multi-channel MCP sidebar for Cursor with concurrent workspaces, per-window binding, image/file attachments and session memos. ![GitHub Repo stars](https://img.shields.io/github/stars/2029193370/cursor-mcp)
 
 ## Rules
 


### PR DESCRIPTION
Adds **Cursor MCP** — a multi-channel MCP sidebar extension for Cursor.

### What it does
- Up to 32 parallel MCP channels in one sidebar (`cursor-mcp-1` … `cursor-mcp-N`)
- Each Cursor chat window binds to exactly one channel — no cross-talk
- Messages can attach images and files
- Per-session memos, concurrent workspace support

### Links
- Repo: https://github.com/2029193370/cursor-mcp
- Release: https://github.com/2029193370/cursor-mcp/releases/tag/v1.0.0
- License: MIT