### PR TITLE
Add promptlint-mcp (static linter for AI prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp): Static linter for AI prompts. Catches contradictions, redundancy, ambiguity, long examples, and politeness fluff. CLI + MCP server. Zero network, MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/sean-sunagaku/promptlint-mcp)
 
 
 


### PR DESCRIPTION
Adds [promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp) under **MCPs**.

It detects contradictions, redundancy, ambiguous pronouns, oversized examples, and politeness fluff in system prompts and agent instructions. Returns a score + issue list + sentence-aware trimmed text. Zero network, zero LLM calls. CLI + MCP server. MIT.

Cursor users can install via the standard MCP configuration. Tools exposed:
- `lint_prompt(text)` - score, issues, trimmed text, token savings
- `trim_prompt(text)` - mechanically trimmed prompt (preserves quoted / backticked / fenced content)