### PR TITLE
Add supamem under MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [supamem](https://github.com/dzmitrys-dev/supamem/): MCP memory tool usable from Cursor — Qdrant-backed dual-memory for AI coding agents. Persistent semantic + structural memory across Claude Code, Cursor, and OpenCode. ![GitHub Repo stars](https://img.shields.io/github/stars/dzmitrys-dev/supamem)
 
 
 


### PR DESCRIPTION
Adds [supamem](https://github.com/dzmitrys-dev/supamem/) under the MCPs section.

MCP memory tool usable from Cursor — Qdrant-backed dual-memory for AI coding agents. Persistent semantic + structural memory across Claude Code, Cursor, and OpenCode.

`supamem` is a single-binary CLI that wires up a production-grade memory layer for any AI coding assistant. Drop it into a fresh repo, run `supamem init`, and your agents instantly gain:

- 🔍 Semantic search over project notes, ADRs, decisions, and past conversations (hybrid sparse+dense retrieval)
- 🤖 MCP server that any compatible client (Claude Code, Cursor, OpenCode) can talk to
- 🪝 Per-client hooks that auto-load relevant memory at session start and on file edits
- 📊 Welford usage stats so you can see what memory is actually being recalled
- 🧪 Eval harness with a 33-query golden corpus to detect retrieval regressions

MIT-licensed, Python 3.12+, on PyPI: `pip install supamem`.

Battle-tested inside SoftChat (Phases 80.1–80.5) before being extracted into a standalone package. Genuine Cursor-compatible MCP server.
