### PR TITLE
Add API Workbench to Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A list of cursor topics.
 - [specstory](https://github.com/specstoryai/getspecstory): SpecStory automatically saves every Cursor chat and composer session to your local project's .specstory directory. ![GitHub Repo stars](https://img.shields.io/github/stars/specstoryai/getspecstory)
 - [Cursor Stats](https://github.com/Dwtexe/cursor-stats): A Cursor extension that displays your Cursor Subscription usage statistics in the status bar. ![GitHub Repo stars](https://img.shields.io/github/stars/Dwtexe/cursor-stats)
 - [stagewise](https://github.com/stagewise-io/stagewise): stagewise is a browser toolbar that connects your frontend UI to your code ai agents in your code editor. ![GitHub Repo stars](https://img.shields.io/github/stars/stagewise-io/stagewise)
+- [API Workbench](https://github.com/sapph1re/api-workbench): Agent-readable API testing for Cursor. Markdown + JSON reports that AI coding assistants can read and act on. Local-first, no account required. ![GitHub Repo stars](https://img.shields.io/github/stars/sapph1re/api-workbench)
 
 ## Rules
 


### PR DESCRIPTION
## What is this?

[API Workbench](https://github.com/sapph1re/api-workbench) is an open-source VS Code / Cursor extension for API testing that produces **agent-readable output** — making it uniquely suited for Cursor users.

## Why it belongs here

- **Agent-native**: Test results are exported as structured Markdown + JSON reports that AI coding assistants (like Cursor) can read and act on directly
- **Local-first**: No account required, no cloud dependency — collections stored in your project as JSON
- **Free and open-source** (MIT): 127 tests passing, GitHub release available
- **Built for agentic IDEs**: Designed from the ground up with Cursor workflows in mind

## Addition

Added to the **Extensions** section, consistent with other Cursor extensions listed there.