### PR TITLE
Add awesome-cursorrules MDC examples to Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A list of cursor topics.
 - [awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc): Curated list of awesome Cursor Rules .mdc files. ![GitHub Repo stars](https://img.shields.io/github/stars/sanjeed5/awesome-cursor-rules-mdc)
 - [cursorkleosr](https://github.com/kleosr/cursorkleosr): This project provides a streamlined way to work with AI assistants (like Claude or GPT-4) inside the Cursor IDE, making development more autonomous and consistent. It helps the AI remember project context and follow a structured process, even across different sessions. Think of it as giving your AI assistant a reliable memory and a clear playbook.  ![GitHub Repo stars](https://img.shields.io/github/stars/kleosr/cursorkleosr)
 - [cursor-custom-agents-rules-generator](https://github.com/bmadcode/cursor-custom-agents-rules-generator): Maximize the potential of Cursor best practices for Automatic Rule and Custom Agent Generation and Agile Workflows  ![GitHub Repo stars](https://img.shields.io/github/stars/bmadcode/cursor-custom-agents-rules-generator)
+- [tugkanboz/awesome-cursorrules](https://github.com/tugkanboz/awesome-cursorrules): Modern Cursor Rules examples in MDC format with nested rules and ready-to-use test automation framework templates (Cypress, Selenium, Playwright, k6). ![GitHub Repo stars](https://img.shields.io/github/stars/tugkanboz/awesome-cursorrules)
 
 
 ## Models


### PR DESCRIPTION
Adds tugkanboz/awesome-cursorrules to the Rules section.

It's a curated set of modern Cursor Rules in MDC format, with nested rule directories and ready to copy examples for test automation frameworks like Cypress, Selenium, Playwright and k6. It sits naturally next to the other rules collections already listed here.

Repo: https://github.com/tugkanboz/awesome-cursorrules
