### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A list of cursor topics.
 
 
 
+- [EGC](https://github.com/Fmarzochi/EGC): Persistent cross-session memory for Cursor and 12 other AI coding tools. SQLite-backed state survives context resets. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC)
+
 
 ## Skills
 


### PR DESCRIPTION
## Summary

- Adds [EGC](https://github.com/Fmarzochi/EGC) to the MCPs section
- EGC is a persistent cross-session memory MCP server for Cursor and 12 other AI coding tools
- SQLite-backed state survives context resets, keeping project context across sessions
- MIT license, install: `npm install -g @egchq/egc`