### PR TITLE
Add Vestige to MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A list of cursor topics.
 
 
 - [EGC](https://github.com/Fmarzochi/EGC): Persistent cross-session memory for Cursor and 12 other AI coding tools. SQLite-backed state survives context resets. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC)
+- [Vestige](https://github.com/samvallad33/vestige): Local-first cognitive memory MCP server for Cursor and other AI coding agents. SQLite storage, FSRS-6 retention, active forgetting, hybrid retrieval, and correction tools. ![GitHub Repo stars](https://img.shields.io/github/stars/samvallad33/vestige)
 
 
 ## Skills


### PR DESCRIPTION
Adds Vestige to the MCPs section.

Vestige is a local-first cognitive memory MCP server for AI coding agents, and it works with Cursor. It stores memory locally in SQLite with FSRS-6 retention, active forgetting, hybrid retrieval, and correction tools.

Placed it right after the EGC entry since both are memory-focused MCP tools. The entry matches the existing format with the same description plus GitHub stars badge style. No CONTRIBUTING file is present, so I followed the README conventions for the section.