### PR TITLE
Add AI Game Developer MCP suite to MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) - Open-source MCP server connecting AI agents (including Cursor) to the Unity Editor and runtime, with 100+ built-in tools.
+- [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) - Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
+- [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP) - Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).
+- [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) - Open-source, engine-agnostic MCP server shared by Unity-MCP, Godot-MCP, and Unreal-MCP.
 
 
 


### PR DESCRIPTION
Adds our open-source (Apache-2.0) MCP suite: Unity-MCP, Godot-MCP, and Unreal-MCP connect AI coding agents including Cursor to their game engines' editors/runtimes via Anthropic's Model Context Protocol; GameDev-MCP-Server is the shared engine-agnostic server underneath them. Maintained at github.com/IvanMurzak/. Happy to adjust to match your conventions — thanks for maintaining this list!