### PR TITLE
Add Shots MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A list of cursor topics.
 
 
 - [EGC](https://github.com/Fmarzochi/EGC): Persistent cross-session memory for Cursor and 12 other AI coding tools. SQLite-backed state survives context resets. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC)
+- [Shots](https://github.com/hitSlop/shots): App Store screenshot, app icon, and ASO listing copy generation for mobile apps through hosted MCP server. Remote endpoint: `https://shots.run/api/mcp`. ![GitHub Repo stars](https://img.shields.io/github/stars/hitSlop/shots)
 
 
 ## Skills


### PR DESCRIPTION
Adding Shots to the MCPs section.

Shots is a hosted MCP server for generating App Store screenshots, app icons, and ASO listing copy for mobile apps.

- Repository: https://github.com/hitSlop/shots
- Remote endpoint: https://shots.run/api/mcp
- Works with Cursor and all MCP clients