### PR TITLE
Add Agent Teams AI to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A list of cursor topics.
 - [Chrome Debug Monitor](https://github.com/Maxteabag/cursor-chrome-composer): A powerful integration between Chrome's DevTools Protocol and Cursor Composer for real-time debugging and monitoring. ![GitHub Repo stars](https://img.shields.io/github/stars/Maxteabag/cursor-chrome-composer)
 - [Coco](https://github.com/rkz91/coco): 389-expert advisory board (9 teams) with optional `--debate` deliberation, 146 skills, 277 commands, and multi-agent orchestration for Cursor (also Claude Code and Codex). MIT. ![GitHub Repo stars](https://img.shields.io/github/stars/rkz91/coco)
 - [cursor-tools](https://github.com/dougwithseismic/cursor-tools): A powerful desktop application for managing and enhancing your Cursor IDE notepads, built with Electron, React, and TypeScript. ![GitHub Repo stars](https://img.shields.io/github/stars/dougwithseismic/cursor-tools)
+- [Agent Teams AI](https://github.com/777genius/agent-teams-ai): A free, open-source desktop app for autonomous coding-agent teams, with Cursor Agent support, task delegation, inter-agent messaging, a live Kanban board, and code review. ![GitHub Repo stars](https://img.shields.io/github/stars/777genius/agent-teams-ai)
 
 ## Extensions
 


### PR DESCRIPTION
Adds Agent Teams AI to the Projects section.

It is a free, open-source desktop app for autonomous coding-agent teams and supports Cursor Agent alongside other runtimes. The entry highlights task delegation, inter-agent messaging, the live Kanban board, and code review.

Validation:

- Confirmed the project link and star badge URL
- Checked for existing entries, issues, and pull requests
- Ran `git diff --check`

Disclosure: I maintain Agent Teams AI.
