### PR TITLE
Add free anti-UI-slop Cursor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A list of cursor topics.
 ## Skills
 
 - [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
+- [UIZZE anti-UI-slop](https://uizze.com): Free, MIT-licensed Cursor skill and finish-gate workflow that turns real interface evidence into a product-specific design contract, then blocks generic card grids, filler metrics, missing states, and inert controls before shipping. No account or MCP required. [Source](https://github.com/samuelbushi/uizze). ![GitHub Repo stars](https://img.shields.io/github/stars/samuelbushi/uizze)
 
 ## Other
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A list of cursor topics.
 ## Skills
 
 - [agentskill.sh](https://agentskill.sh): Browse and install 44k+ skills for Cursor, Claude Code, Codex with security scanning. Use `/learn` command for one-click install.
-- [UIZZE anti-UI-slop](https://uizze.com): Free, MIT-licensed Cursor skill and finish-gate workflow that turns real interface evidence into a product-specific design contract, then blocks generic card grids, filler metrics, missing states, and inert controls before shipping. No account or MCP required. [Source](https://github.com/samuelbushi/uizze). ![GitHub Repo stars](https://img.shields.io/github/stars/samuelbushi/uizze)
+- [UIZZE anti-UI-slop](https://uizze.com): Free, MIT-licensed Cursor skill and finish-gate workflow that turns real interface evidence into a product-specific design contract, then blocks generic card grids, filler metrics, missing states, and inert controls before shipping. No account or MCP required. [Source](https://github.com/uizze/uizze). ![GitHub Repo stars](https://img.shields.io/github/stars/uizze/uizze)
 
 ## Other
 


### PR DESCRIPTION
## What changed

Adds UIZZE anti-UI-slop to the existing **Skills** section as a free, MIT-licensed Cursor skill and finish-gate workflow.

The entry explains the useful free behavior: it turns real interface evidence into a product-specific design contract, then blocks generic card grids, filler metrics, missing states, and inert controls before shipping. It also links the public source and states that the free skill needs no account or MCP connection.

## Why this category

This is an installable Cursor skill with a checked-in `.cursor-plugin/plugin.json` and `skills/anti-ui-slop/SKILL.md`, so **Skills** is more precise than Projects, Rules, or MCPs. The entry is not a bare SaaS listing.

## Checks

- changed one README line under **Skills** only
- verified the `https://uizze.com` URL has no tracking parameters
- verified no pricing, credentials, tokens, download claims, or fabricated metrics were added
- `git diff --cached --check`
