### PR TITLE
Add MemoryPlugin to MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A list of cursor topics.
 
 
 - [EGC](https://github.com/Fmarzochi/EGC): Persistent cross-session memory for Cursor and 12 other AI coding tools. SQLite-backed state survives context resets. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC)
+- [MemoryPlugin](https://help.memoryplugin.com/integrations/remote-mcp-server): Long-term memory shared between Cursor and 21+ AI tools (ChatGPT, Claude, Gemini) over MCP. Store, search, and recall memories organized in buckets; hosted remote server with OAuth or local `npx @memoryplugin/mcp-server`.
 
 
 ## Skills


### PR DESCRIPTION
Adds MemoryPlugin to the MCPs section.

MemoryPlugin is a long-term memory layer that Cursor can use over MCP: tools to store, search, and recall memories organized in buckets, shared with ChatGPT, Claude, Gemini, and 21+ supported AI tools. Cursor connects via the hosted remote server (OAuth, `https://www.memoryplugin.com/api/mcp/mcp`) or the local `npx @memoryplugin/mcp-server` package; setup docs for Cursor are on the linked page.

Note on format: the entry links the MCP setup docs rather than a GitHub repo (the server is distributed via npm), so it carries no star shield — same as the existing smithery.ai entry. Happy to adjust if you prefer a different link.

Disclosure: I'm the maker of MemoryPlugin.