### PR TITLE
Add ParlayAPI MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A list of cursor topics.
 
 - [EGC](https://github.com/Fmarzochi/EGC): Persistent cross-session memory for Cursor and 12 other AI coding tools. SQLite-backed state survives context resets. ![GitHub Repo stars](https://img.shields.io/github/stars/Fmarzochi/EGC)
 
+- [ParlayAPI MCP](https://github.com/JacobiusMakes/parlay-api-mcp): Sports odds and source coverage for personal or internal research, with keyless discovery and authenticated access using your own API key. ![GitHub Repo stars](https://img.shields.io/github/stars/JacobiusMakes/parlay-api-mcp)
 
 ## Skills
 


### PR DESCRIPTION
Adds ParlayAPI MCP to the MCPs section for developers researching sports odds and source coverage in personal or internal projects. I maintain ParlayAPI.

Discovery works without a key; authenticated odds access uses each user's own API key.

Validation: checked the current README and prior issues/PRs for duplicates, verified the source and badge links, and matched the existing entry format.
