### PR TITLE
Add SnipperApp MCP to MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A list of cursor topics.
 - [Cursor MCP](https://github.com/johnneerdael/multiplatform-cursor-mcp): Cursor MCP is a bridge between Claude's desktop application and the Cursor editor, enabling seamless AI-powered automation and multi-instance management. It's part of the broader Model Context Protocol (MCP) ecosystem, allowing Cursor to interact with various AI models and services through standardized interfaces.  ![GitHub Repo stars](https://img.shields.io/github/stars/johnneerdael/multiplatform-cursor-mcp)
 - [context7](https://github.com/upstash/context7): Context7 MCP Server -- Up-to-date documentation for LLMs and AI code editors. ![GitHub Repo stars](https://img.shields.io/github/stars/upstash/context7)
 - [claude-task-master](https://github.com/eyaltoledano/claude-task-master): An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others. ![GitHub Repo stars](https://img.shields.io/github/stars/eyaltoledano/claude-task-master)
+- [SnipperApp MCP](https://snipperapp.com/docs/mcp-integration): Bundled MCP server of the SnipperApp 3 snippet manager for macOS; lets Cursor search, read, and save your code snippets.
 
 
 


### PR DESCRIPTION

Adds SnipperApp's bundled MCP server to the MCPs section. It ships inside the SnipperApp 3 macOS app (stdio, no install) and lets Cursor search, read and save code snippets from the user's library. Setup: https://snipperapp.com/docs/mcp-integration. I'm the developer.