### PR TITLE
Add kgai to Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A list of cursor topics.
 - [Cursor Stats](https://github.com/Dwtexe/cursor-stats): A Cursor extension that displays your Cursor Subscription usage statistics in the status bar. ![GitHub Repo stars](https://img.shields.io/github/stars/Dwtexe/cursor-stats)
 - [stagewise](https://github.com/stagewise-io/stagewise): stagewise is a browser toolbar that connects your frontend UI to your code ai agents in your code editor. ![GitHub Repo stars](https://img.shields.io/github/stars/stagewise-io/stagewise)
 - [Cursor MCP](https://github.com/2029193370/cursor-mcp): Multi-channel MCP sidebar for Cursor with concurrent workspaces, per-window binding, image/file attachments and session memos. ![GitHub Repo stars](https://img.shields.io/github/stars/2029193370/cursor-mcp)
+- [kgai](https://github.com/kgaidev/kgai): Read-only sidebar with the team's engineering decision log. Decisions newest first, contested elements side by side, the live graph. Installs from Open VSX, no AI in the reader. ![GitHub Repo stars](https://img.shields.io/github/stars/kgaidev/kgai)
 
 ## Plugins
 


### PR DESCRIPTION
Adds kgai at the end of the Extensions section, one line in the section's format.

Disclosure, we build kgai. The extension shows a project's recorded engineering decisions in the editor sidebar, read only, newest first, contested elements side by side, plus the live graph. It installs into Cursor from Open VSX (https://open-vsx.org/extension/kgaidev/kgai). There is no AI in the reader, it only reads the decision log that the kgai CLI and the Claude Code plugin write.

Happy to adjust wording or placement.
